### PR TITLE
btd: recognize 'D' (deleted) change prefix

### DIFF
--- a/btd/src/sapling/status.rs
+++ b/btd/src/sapling/status.rs
@@ -42,6 +42,7 @@ impl Status<ProjectRelativePath> {
             Some('A') => Ok(Self::Added(path)),
             Some('M') => Ok(Self::Modified(path)),
             Some('R') => Ok(Self::Removed(path)),
+            Some('D') => Ok(Self::Removed(path)), // used by jujutsu
             _ => Err(StatusParseError::UnknownPrefix(value.to_owned()).into()),
         }
     }


### PR DESCRIPTION
Sapling/Mercurial use 'R' for deleted files. Jujutsu uses 'D'. Support both.