### PR TITLE
Fix "cargo-clippy is not installed" in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2023-11-10
+        toolchain: nightly-2025-03-29
         components: clippy, rustfmt
     # We use rustfmt 2.0 for formatting, which differs from the released
     # version installed by Cargo


### PR DESCRIPTION
<img width="1106" alt="Screenshot 2025-06-08 at 6 12 18 PM" src="https://github.com/user-attachments/assets/de75100b-454d-4443-aac3-0cf732a14fe5" />

Differential Revision: D76235458


