### PR TITLE
Add git support to BTD via a --vcs flag

### DIFF
--- a/btd/README.md
+++ b/btd/README.md
@@ -22,8 +22,10 @@ Where:
 
 - `btd` is the binary. Within Meta a precompiled version of `btd` is available
   at `~/fbsource/tools/utd/btd/btd`.
-- `changes.txt` is the output of
-  `hg status --rev hash_before::hash_after -amr --root-relative`.
+- `changes.txt` is the list of changed files. On a Sapling/Mercurial repo it is
+  the output of `hg status --rev hash_before::hash_after -amr --root-relative`;
+  on a git repo it is the output of
+  `git diff --name-status hash_before hash_after`. See `--vcs` below.
 - `base.jsonl` is the output of `supertd targets cell//... --output base.jsonl`
   in the base state, before the changes. Pass `--dry-run` to see the `buck2`
   command that is equivalent to.
@@ -43,6 +45,17 @@ configuration with the flags:
 - `--config ~/data/config.json` is the output of `supertd audit config` in the
   root of the repo. If `--cells` is present but `--config` is absent then BTD
   will use the Buck2 default values for all `.buckconfig` settings.
+
+## Specifying the VCS (`--vcs`)
+
+The `--vcs` flag declares which version-control system produced the `--changes`
+file, so BTD interprets its status format correctly. It accepts:
+
+- `sapling` (aliases `sl`, `hg`) — the default. Parses `hg`/`sl status` output
+  (a status character, a space, then a root-relative path).
+- `git` — parses `git diff --name-status` output (tab-separated). Renames and
+  copies (`R100`/`C75`) are expanded to a remove of the old path plus an add of
+  the new one, so impact stays conservative.
 
 ## When to use BTD
 

--- a/btd/src/lib.rs
+++ b/btd/src/lib.rs
@@ -47,6 +47,7 @@ use td_util::json;
 use td_util::logging::elapsed;
 use td_util::logging::step;
 use td_util::prelude::*;
+use td_util::vcs::Vcs;
 use td_util::workflow_error::WorkflowError;
 use td_util_buck::cells::CellInfo;
 use td_util_buck::run::Buck2;
@@ -57,6 +58,7 @@ use td_util_buck::types::TargetLabelKeyRef;
 use td_util_buck::types::TargetPattern;
 use tempfile::NamedTempFile;
 use thiserror::Error;
+use tracing::debug;
 use tracing::error;
 
 use crate::changes::Changes;
@@ -85,6 +87,11 @@ pub struct Args {
     /// File containing the output of `hg status` for the relevant diff.
     #[arg(long, value_name = "FILE")]
     changes: PathBuf,
+
+    /// VCS platform that produced the `--changes` file. Accepts `sapling`
+    /// (aliases `sl`, `hg`) or `git`; defaults to Sapling.
+    #[arg(long, default_value = "sapling")]
+    vcs: Vcs,
 
     /// File containing the JSON output from `buck2 targets` base the change.
     #[arg(long, value_name = "FILE")]
@@ -217,6 +224,7 @@ pub fn main(args: Args) -> Result<(), WorkflowError> {
     }
 
     step("reading changes");
+    debug!("Interpreting `--changes` as {:?} VCS output", args.vcs);
     let changes = Changes::new(&cells, read_status(&args.changes)?)?;
     step("reading base");
     let base = leak_targets(Targets::from_file(&args.base)?);

--- a/btd/src/sapling/status.rs
+++ b/btd/src/sapling/status.rs
@@ -32,6 +32,26 @@ enum StatusParseError {
     UnknownPrefix(String),
 }
 
+/// Split a status line into its leading status token and the remainder,
+/// accepting either a space (`sl`/`hg`) or a tab (`git --name-status`) as the
+/// separator. Returns `None` if there is no separator or the token is empty.
+fn split_status_token(line: &str) -> Option<(&str, &str)> {
+    let idx = line.find([' ', '\t'])?;
+    if idx == 0 {
+        return None;
+    }
+    Some((&line[..idx], &line[idx + 1..]))
+}
+
+/// Whether `token` is a git similarity-scored status like `R100` or `C75`,
+/// i.e. `prefix` followed by one or more ASCII digits.
+fn is_scored(token: &str, prefix: char) -> bool {
+    let mut chars = token.chars();
+    chars.next() == Some(prefix)
+        && !token[1..].is_empty()
+        && token[1..].bytes().all(|b| b.is_ascii_digit())
+}
+
 impl Status<ProjectRelativePath> {
     /// Creates a new Modified status from a file path string
     pub fn modified(path: &str) -> Self {
@@ -48,20 +68,53 @@ impl Status<ProjectRelativePath> {
         Self::Removed(ProjectRelativePath::new(path))
     }
 
+    /// Parse a single-path status line (one of `sl`/`hg`'s `M path`, or
+    /// git's `M\tpath`). Rename/copy lines carry two paths and must go
+    /// through [`Status::parse_line`] instead.
     fn from_str(value: &str) -> anyhow::Result<Self> {
-        let mut it = value.chars();
-        let typ = it.next();
-        if it.next() != Some(' ') {
-            return Err(StatusParseError::UnexpectedFormat(value.to_owned()).into());
-        }
-        let path = ProjectRelativePath::new(it.as_str());
+        let (typ, path) = split_status_token(value)
+            .ok_or_else(|| StatusParseError::UnexpectedFormat(value.to_owned()))?;
+        let path = ProjectRelativePath::new(path);
         match typ {
-            Some('A') => Ok(Self::Added(path)),
-            Some('M') => Ok(Self::Modified(path)),
-            Some('R') => Ok(Self::Removed(path)),
-            Some('D') => Ok(Self::Removed(path)), // used by jujutsu
+            "A" => Ok(Self::Added(path)),
+            // `T` is git's "typechange" (e.g. file <-> symlink); treat as a
+            // modification for impact purposes.
+            "M" | "T" => Ok(Self::Modified(path)),
+            "R" => Ok(Self::Removed(path)),
+            "D" => Ok(Self::Removed(path)), // used by git and jujutsu
             _ => Err(StatusParseError::UnknownPrefix(value.to_owned()).into()),
         }
+    }
+
+    /// Parse a single status line into one or more statuses.
+    ///
+    /// Handles both Sapling/Mercurial `sl status` output (`M path`, space
+    /// separated) and git `git diff --name-status` output (`M\tpath`, tab
+    /// separated). A git rename (`R<score>\told\tnew`) expands to a
+    /// [`Status::Removed`] of the old path plus a [`Status::Added`] of the new
+    /// one; a copy (`C<score>\told\tnew`) yields a single [`Status::Added`] of
+    /// the new path (the source is untouched). This mirrors what BTD would see
+    /// had rename detection been disabled, so downstream impact analysis stays
+    /// conservative.
+    fn parse_line(value: &str) -> anyhow::Result<Vec<Self>> {
+        let (token, rest) = split_status_token(value)
+            .ok_or_else(|| StatusParseError::UnexpectedFormat(value.to_owned()))?;
+        if is_scored(token, 'R') {
+            let (old, new) = rest
+                .split_once('\t')
+                .ok_or_else(|| StatusParseError::UnexpectedFormat(value.to_owned()))?;
+            return Ok(vec![
+                Self::Removed(ProjectRelativePath::new(old)),
+                Self::Added(ProjectRelativePath::new(new)),
+            ]);
+        }
+        if is_scored(token, 'C') {
+            let (_old, new) = rest
+                .split_once('\t')
+                .ok_or_else(|| StatusParseError::UnexpectedFormat(value.to_owned()))?;
+            return Ok(vec![Self::Added(ProjectRelativePath::new(new))]);
+        }
+        Ok(vec![Self::from_str(value)?])
     }
 }
 
@@ -113,10 +166,19 @@ pub fn read_status(path: &Path) -> anyhow::Result<Vec<Status<ProjectRelativePath
     )
 }
 
+/// Parse the textual output of `sl status` / `hg status` / `git diff
+/// --name-status` into a flat list of [`Status`] entries. Blank lines are
+/// ignored; rename/copy lines expand to multiple entries (see
+/// [`Status::parse_line`]).
 pub fn parse_status(data: &str) -> anyhow::Result<Vec<Status<ProjectRelativePath>>> {
-    data.lines()
-        .map(Status::from_str)
-        .collect::<anyhow::Result<Vec<_>>>()
+    let mut out = Vec::new();
+    for line in data.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        out.extend(Status::parse_line(line)?);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -143,10 +205,49 @@ R quux.js
     }
 
     #[test]
+    fn test_status_git_name_status_tab_separated() {
+        let src = "M\tproj/foo.rs\nA\tbaz/file.txt\nD\tquux.js\nT\tsym.link\n";
+        assert_eq!(
+            parse_status(src).unwrap(),
+            vec![
+                Status::Modified(ProjectRelativePath::new("proj/foo.rs")),
+                Status::Added(ProjectRelativePath::new("baz/file.txt")),
+                Status::Removed(ProjectRelativePath::new("quux.js")),
+                Status::Modified(ProjectRelativePath::new("sym.link")),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_status_git_rename_and_copy_expand() {
+        let src = "R100\told/name.rs\tnew/name.rs\nC075\tsrc/a.rs\tsrc/b.rs\n";
+        assert_eq!(
+            parse_status(src).unwrap(),
+            vec![
+                Status::Removed(ProjectRelativePath::new("old/name.rs")),
+                Status::Added(ProjectRelativePath::new("new/name.rs")),
+                Status::Added(ProjectRelativePath::new("src/b.rs")),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_status_path_with_spaces() {
+        let src = "M\tdir/with space/file.rs\n";
+        assert_eq!(
+            parse_status(src).unwrap(),
+            vec![Status::Modified(ProjectRelativePath::new(
+                "dir/with space/file.rs"
+            ))]
+        );
+    }
+
+    #[test]
     fn test_status_error() {
         assert!(parse_status("X quux.js").is_err());
         assert!(parse_status("notaline").is_err());
         assert!(parse_status("not a line").is_err());
+        assert!(parse_status("R100\tonlyoldpath").is_err());
     }
 
     #[test]

--- a/td_util/Cargo.toml
+++ b/td_util/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 argfile = "0.1.5"
-clap = {version = "4.1.4"}
+clap = {version = "4.1.4", features = ["derive"]}
 equivalent = "1.0.0"
 fbinit = { workspace = true }
 fbinit-tokio = { workspace = true }

--- a/td_util/src/git.rs
+++ b/td_util/src/git.rs
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is dual-licensed under either the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree or the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree. You may select, at your option, one of the
+ * above-listed licenses.
+ */
+
+//! Thin shell-out wrappers around the `git` CLI, mirroring [`crate::sapling`]
+//! so callers on a plain git repository get the same read-only status / log
+//! queries without a native git library. Output is shaped to be consumed by
+//! BTD's `read_status` (`<status> <path>` lines, one per change).
+//!
+//! Two deliberate choices keep git output faithful to what BTD expects:
+//!
+//! * `--name-status --no-renames` — a rename surfaces as a delete of the old
+//!   path plus an add of the new one, which is the conservative signal target
+//!   determination wants (both packages are rebuilt) and avoids git's rename
+//!   detection, which is O(files) and slow on very large diffs.
+//! * `-c core.quotepath=false` — non-ASCII paths are emitted literally instead
+//!   of octal-escaped, so paths round-trip unchanged (the moral equivalent of
+//!   Sapling's `HGPLAIN=1`).
+//!
+//! Sync helpers spawn via `std::process::Command`; async helpers (used from
+//! `tokio` contexts) spawn via `tokio::process::Command`.
+
+use std::io::Write as _;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::NamedTempFile;
+use tokio::process::Command as AsyncCommand;
+
+/// Config args applied to every `git` invocation for deterministic,
+/// machine-parseable output regardless of the user's git config.
+const DETERMINISTIC_ARGS: [&str; 2] = ["-c", "core.quotepath=false"];
+
+/// Run `git diff --name-status --no-renames FROM TO`, returning the raw
+/// stdout. Compares the two revisions directly (endpoint to endpoint, like
+/// `git diff FROM..TO`), matching `sl status --rev FROM --rev TO`. Errors if
+/// `git` fails to spawn or exits non-zero.
+pub fn git_status(from_hash: &str, to_hash: &str) -> anyhow::Result<String> {
+    let output = Command::new("git")
+        .args(DETERMINISTIC_ARGS)
+        .args(["diff", "--name-status", "--no-renames", from_hash, to_hash])
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git diff --name-status {from_hash} {to_hash} failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+/// Number of commits reachable from `to_hash` but not from `from_hash`
+/// (`git rev-list --count FROM..TO`), i.e. the exclusive commit distance.
+/// `None` on shell failure or unparseable output.
+pub fn git_log_count(from_hash: &str, to_hash: &str) -> Option<i64> {
+    let stdout = run_git(&["rev-list", "--count", &format!("{from_hash}..{to_hash}")])?;
+    stdout.trim().parse::<i64>().ok()
+}
+
+/// Unix epoch seconds of the commit identified by `rev`
+/// (`git log -1 --format=%ct REV`). Mirrors [`crate::sapling::sl_log_timestamp`].
+/// `None` on shell failure or if the output isn't parseable.
+pub fn git_log_timestamp(rev: &str) -> Option<i64> {
+    let stdout = run_git(&["log", "-1", "--format=%ct", rev])?;
+    stdout.trim().parse::<i64>().ok()
+}
+
+/// The repository root (`git rev-parse --show-toplevel`), run in `cwd` (or the
+/// process working directory when `None`). The async counterpart to the
+/// Sapling [`crate::sapling::repo_root`].
+pub async fn repo_root(cwd: Option<&Path>) -> anyhow::Result<PathBuf> {
+    let stdout = run_git_async(&["rev-parse", "--show-toplevel"], cwd).await?;
+    Ok(PathBuf::from(stdout.trim()))
+}
+
+/// The current commit hash (`git rev-parse HEAD`), run in `cwd` (or the
+/// process working directory when `None`).
+pub async fn current_revision(cwd: Option<&Path>) -> anyhow::Result<String> {
+    let stdout = run_git_async(&["rev-parse", "HEAD"], cwd).await?;
+    Ok(stdout.trim().to_owned())
+}
+
+/// Working-copy changes relative to `HEAD` (staged and unstaged), plus
+/// untracked files reported as additions, suitable for BTD's `read_status`.
+/// Mirrors Sapling's `sl status -amr`.
+pub async fn status_working_copy(cwd: Option<&Path>) -> anyhow::Result<String> {
+    let mut out = run_git_async(&["diff", "--name-status", "--no-renames", "HEAD"], cwd).await?;
+    // Untracked files are not part of `git diff`; list them explicitly and
+    // present each as an addition so new sources register as changes.
+    let untracked = run_git_async(&["ls-files", "--others", "--exclude-standard"], cwd).await?;
+    for path in untracked.lines() {
+        if !path.is_empty() {
+            out.push('A');
+            out.push('\t');
+            out.push_str(path);
+            out.push('\n');
+        }
+    }
+    Ok(out)
+}
+
+/// The changeset between two revisions (`git diff --name-status --no-renames
+/// BASE DIFF`), suitable for BTD's `read_status`. Mirrors Sapling's
+/// `status_range`.
+pub async fn status_range(base: &str, diff: &str, cwd: Option<&Path>) -> anyhow::Result<String> {
+    run_git_async(
+        &["diff", "--name-status", "--no-renames", base, diff],
+        cwd,
+    )
+    .await
+}
+
+/// Unified git-format diff for `files` between two revisions
+/// (`git diff BASE DIFF -- <files>`). Native git output; no reformatting.
+pub async fn diff_git(
+    base: &str,
+    diff: &str,
+    files: &[&str],
+    cwd: Option<&Path>,
+) -> anyhow::Result<String> {
+    let mut args = vec!["diff", base, diff, "--"];
+    args.extend_from_slice(files);
+    run_git_async(&args, cwd).await
+}
+
+/// Write the changeset between two revisions to a fresh `NamedTempFile`, the
+/// shape BTD consumes (`--changes`). Convenience over [`status_range`].
+pub async fn changeset_tempfile(
+    base: &str,
+    diff: &str,
+    cwd: Option<&Path>,
+) -> anyhow::Result<NamedTempFile> {
+    write_temp(&status_range(base, diff, cwd).await?)
+}
+
+/// Write the working-copy changeset to a fresh `NamedTempFile`.
+/// Convenience over [`status_working_copy`].
+pub async fn working_copy_changeset_tempfile(cwd: Option<&Path>) -> anyhow::Result<NamedTempFile> {
+    write_temp(&status_working_copy(cwd).await?)
+}
+
+fn run_git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(DETERMINISTIC_ARGS)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
+/// Run `git <args>` with deterministic config, optionally in `cwd`, returning
+/// stdout. Errors if `git` fails to spawn or exits non-zero.
+async fn run_git_async(args: &[&str], cwd: Option<&Path>) -> anyhow::Result<String> {
+    let mut cmd = AsyncCommand::new("git");
+    cmd.args(DETERMINISTIC_ARGS).args(args);
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let output = cmd.output().await?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {} failed:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn write_temp(contents: &str) -> anyhow::Result<NamedTempFile> {
+    let mut tmp = NamedTempFile::new()?;
+    tmp.write_all(contents.as_bytes())?;
+    Ok(tmp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_args_disable_quotepath() {
+        // The literal-path flag must be present so non-ASCII paths round-trip.
+        assert_eq!(DETERMINISTIC_ARGS, ["-c", "core.quotepath=false"]);
+    }
+
+    #[test]
+    fn write_temp_roundtrips_contents() {
+        let tmp = write_temp("M\tfoo.rs\n").unwrap();
+        let read = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(read, "M\tfoo.rs\n");
+    }
+}

--- a/td_util/src/lib.rs
+++ b/td_util/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cli;
 pub mod command;
 pub mod executor;
 pub mod file_io;
+pub mod git;
 pub mod json;
 pub mod knobs;
 pub mod logging;
@@ -25,6 +26,7 @@ pub mod string;
 pub mod supertd_events;
 // @oss-disable: pub mod supertd_events_logger;
 pub mod tracing;
+pub mod vcs;
 pub mod workflow_error;
 pub mod zstd;
 

--- a/td_util/src/vcs.rs
+++ b/td_util/src/vcs.rs
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is dual-licensed under either the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree or the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree. You may select, at your option, one of the
+ * above-listed licenses.
+ */
+
+//! Version-control abstraction so target determination works on either a
+//! Sapling/Mercurial checkout or a plain git repository. Callers pick the
+//! backend explicitly (e.g. via the `--vcs` flag) and use the uniform helpers,
+//! which dispatch to [`crate::sapling`] or [`crate::git`]. Both backends emit
+//! changesets in the `<status> <path>` shape BTD's `read_status` consumes.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use clap::ValueEnum;
+
+use crate::git;
+use crate::sapling;
+
+/// The version-control system backing a checkout. Also usable directly as a
+/// clap argument (`--vcs sapling|sl|hg|git`), defaulting to [`Vcs::Sapling`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum Vcs {
+    /// Sapling or Mercurial — both driven through the `sl` CLI. The default.
+    #[default]
+    #[value(name = "sapling", aliases = ["sl", "hg"])]
+    Sapling,
+    #[value(name = "git")]
+    Git,
+}
+
+impl Vcs {
+    /// Synchronously compute the changeset between two revisions, in the
+    /// `<status> <path>` shape BTD's `read_status`/`parse_status` consumes.
+    /// Uses the backend's blocking helper so callers on a plain thread (e.g.
+    /// BTD's synchronous `main`) don't need a tokio runtime.
+    pub fn status(&self, base: &str, diff: &str) -> anyhow::Result<String> {
+        match self {
+            Vcs::Git => git::git_status(base, diff),
+            Vcs::Sapling => sapling::sl_status(base, diff),
+        }
+    }
+
+    /// The changeset between two revisions, in `read_status` shape.
+    pub async fn status_range(
+        &self,
+        base: &str,
+        diff: &str,
+        cwd: Option<&Path>,
+    ) -> anyhow::Result<String> {
+        match self {
+            Vcs::Git => git::status_range(base, diff, cwd).await,
+            Vcs::Sapling => sapling::status_range(base, diff, cwd).await,
+        }
+    }
+
+    /// The working-copy changeset (changes relative to the parent commit), in
+    /// `read_status` shape.
+    pub async fn status_working_copy(&self, cwd: Option<&Path>) -> anyhow::Result<String> {
+        match self {
+            Vcs::Git => git::status_working_copy(cwd).await,
+            Vcs::Sapling => sapling::status_working_copy(cwd).await,
+        }
+    }
+
+    /// The repository root.
+    pub async fn repo_root(&self, cwd: Option<&Path>) -> anyhow::Result<PathBuf> {
+        match self {
+            Vcs::Git => git::repo_root(cwd).await,
+            Vcs::Sapling => sapling::repo_root(cwd).await,
+        }
+    }
+
+    /// The current commit hash.
+    pub async fn current_revision(&self, cwd: Option<&Path>) -> anyhow::Result<String> {
+        match self {
+            Vcs::Git => git::current_revision(cwd).await,
+            Vcs::Sapling => sapling::current_revision(cwd).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::ValueEnum;
+
+    use super::*;
+
+    #[test]
+    fn value_enum_accepts_aliases() {
+        // `sl`, `hg`, and `sapling` all mean the Mercurial/Sapling backend.
+        assert_eq!(Vcs::from_str("sapling", true).unwrap(), Vcs::Sapling);
+        assert_eq!(Vcs::from_str("sl", true).unwrap(), Vcs::Sapling);
+        assert_eq!(Vcs::from_str("hg", true).unwrap(), Vcs::Sapling);
+        assert_eq!(Vcs::from_str("git", true).unwrap(), Vcs::Git);
+        assert!(Vcs::from_str("svn", true).is_err());
+    }
+
+    #[test]
+    fn default_is_sapling() {
+        assert_eq!(Vcs::default(), Vcs::Sapling);
+    }
+}


### PR DESCRIPTION
## Summary

Adds git support to BTD alongside the existing Sapling/Mercurial path.

- **`td_util::git`** — a `git` CLI shell-out layer mirroring `td_util::sapling`.
- **`td_util::vcs::Vcs`** — a `{ Sapling, Git }` backend selector (clap `ValueEnum`).
- **Format-agnostic parser** — BTD's status parser now also reads
  `git diff --name-status` (tabs, `D` deletes, `R###`/`C###` rename/copy).
- **`--vcs sapling|git` flag** on `btd` (default Sapling), documented in the README.
  The base `--changes` flow is unchanged.

## Test plan

- `cargo build && cargo clippy && cargo test` — green on ubuntu/macOS/windows toolchain.
- New unit tests: git name-status / rename / copy parsing, `--vcs` alias parsing.